### PR TITLE
fix(compose): load .env via env_file

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -21,3 +21,6 @@ services:
       - ./log:/app/log
 
     restart: unless-stopped
+    
+    env_file:
+      - .env


### PR DESCRIPTION
Compose 的 .env 默认只用于变量替换，不会自动注入容器环境变量。
在 docker-compose.ghcr.yml 增加 env_file: - .env，让 AG2API_* 配置（如 AG2API_API_KEYS）能传入容器。
否则即使设置了 API Key，UI 也可能一直显示“未授权”。