### PR TITLE
Fix: model name mismatch in API responses

### DIFF
--- a/src/api/claudeApi.js
+++ b/src/api/claudeApi.js
@@ -247,7 +247,8 @@ class ClaudeApi {
       const queryString = method === "streamGenerateContent" ? "?alt=sse" : "";
 
       const transformOutOptions = {};
-      if (mcpModel) transformOutOptions.overrideModel = baseModel;
+      // 始终使用原始请求的模型名称,避免响应中返回映射后的模型名
+      transformOutOptions.overrideModel = requestData.model;
       if (!clientWantsStream && method === "streamGenerateContent") transformOutOptions.forceNonStreaming = true;
       if (isMcpXmlEnabled()) {
         const names = getMcpToolNames(requestData?.tools);


### PR DESCRIPTION
确保响应始终返回客户端原始请求的模型名称，而不是映射后的上游模型名称。 
比如，由于模型映射的原因，请求“claude-haiku-4-5-20251001”会在响应中返回“claude-sonnet-4-5”。